### PR TITLE
Detail mode without URL-encoding

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,8 +1,8 @@
 include: "https://raw.githubusercontent.com/dbmdz/development/master/ci/.gitlab-ci-base.yml"
 
 .install_dependencies: &install_dependencies
-  - curl -sS -O https://raw.githubusercontent.com/ExLibrisGroup/Rosetta.dps-sdk-projects/master/5.0.1/dps-sdk-deposit/lib/dps-sdk-5.0.1.jar
-  - mvn install:install-file -Dfile=dps-sdk-5.0.1.jar -DgroupId=com.exlibris.dps -DartifactId=dps-sdk -Dversion=5.0.1 -Dpackaging=jar
+  - curl -sS -O https://raw.githubusercontent.com/ExLibrisGroup/Rosetta.dps-sdk-projects/master/6.3/dps-sdk-projects/dps-sdk-deposit/lib/dps-sdk-6.3.0.jar
+  - mvn install:install-file -Dfile=dps-sdk-6.3.0.jar -DgroupId=com.exlibris.dps -DartifactId=dps-sdk -Dversion=6.3.0 -Dpackaging=jar
 
 .compile:
   before_script: *install_dependencies

--- a/Readme.md
+++ b/Readme.md
@@ -55,8 +55,8 @@ RewriteRule ^/wayback/query$ /wayback%3? [L,PT]
 To build this project the [Rosetta PDS SDK](https://developers.exlibrisgroup.com/rosetta/sdk) from [GitHub](https://github.com/ExLibrisGroup/Rosetta.dps-sdk-projects/tree/master/current/dps-sdk-plugins/lib) is needed as there is no public Maven repository. Note that the jar-Files for "deposit" and "plugin" are the same, but "deposit" has more Rosetta-Versions. To use the SDK, you have to download and install it locally:
 
 ```bash
-curl -sS -O https://raw.githubusercontent.com/ExLibrisGroup/Rosetta.dps-sdk-projects/master/5.0.1/dps-sdk-deposit/lib/dps-sdk-5.0.1.jar
-mvn install:install-file -Dfile=dps-sdk-5.0.1.jar -DgroupId=com.exlibris.dps -DartifactId=dps-sdk -Dversion=5.0.1 -Dpackaging=jar
+curl -sS -O https://raw.githubusercontent.com/ExLibrisGroup/Rosetta.dps-sdk-projects/master/6.3/dps-sdk-projects/dps-sdk-deposit/lib/dps-sdk-6.3.0.jar
+mvn install:install-file -Dfile=dps-sdk-6.3.0.jar -DgroupId=com.exlibris.dps -DartifactId=dps-sdk -Dversion=6.3.0 -Dpackaging=jar
 ```
 
 Building a deployable jar file including all necessary configuration files:

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,8 @@
     <version.jacoco-maven-plugin>0.8.5</version.jacoco-maven-plugin>
     <version.maven-surefire-plugin>3.0.0-M5</version.maven-surefire-plugin>
     <version.tomcat-servlet-api>7.0.105</version.tomcat-servlet-api>
+    <version.fmt-maven-plugin>2.10</version.fmt-maven-plugin>
+    <version.githook-maven-plugin>1.0.5</version.githook-maven-plugin>
   </properties>
 
   <dependencies>
@@ -101,6 +103,44 @@
             <goals>
               <goal>report</goal>
             </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.coveo</groupId>
+        <artifactId>fmt-maven-plugin</artifactId>
+        <version>${version.fmt-maven-plugin}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>format</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>io.github.phillipuniverse</groupId>
+        <artifactId>githook-maven-plugin</artifactId>
+        <version>${version.githook-maven-plugin}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>install</goal>
+            </goals>
+            <configuration>
+              <hooks>
+                <pre-commit>
+                  if ! mvn com.coveo:fmt-maven-plugin:check ; then
+                  mvn com.coveo:fmt-maven-plugin:format
+                  echo -e "\e[31mCode has been reformatted to match code style\e[0m"
+                  echo -e "\e[31mPlease use git add … to add modified files\e[0m"
+                  echo "Your commit message was:"
+                  cat .git/COMMIT_EDITMSG
+                  exit 1
+                  fi
+                </pre-commit>
+              </hooks>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -13,16 +13,15 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <!-- Dependencies -->
-    <version.assertj>3.11.1</version.assertj>
-    <version.dps-sdk>5.0.1</version.dps-sdk>
-    <version.junit-jupiter>5.3.2</version.junit-jupiter>
+    <version.assertj>3.17.0</version.assertj>
+    <version.dps-sdk>6.3.0</version.dps-sdk>
+    <version.junit-jupiter>5.7.0-RC1</version.junit-jupiter>
     <version.mockito-all>2.0.2-beta</version.mockito-all>
     <version.log4j>1.2.17</version.log4j>
     <!-- Plugins -->
-    <version.jacoco-maven-plugin>0.8.3</version.jacoco-maven-plugin>
-    <version.maven-checkstyle-plugin>3.0.0</version.maven-checkstyle-plugin>
-    <version.maven-surefire-plugin>2.22.1</version.maven-surefire-plugin>
-    <version.tomcat-servlet-api>7.0.92</version.tomcat-servlet-api>
+    <version.jacoco-maven-plugin>0.8.5</version.jacoco-maven-plugin>
+    <version.maven-surefire-plugin>3.0.0-M5</version.maven-surefire-plugin>
+    <version.tomcat-servlet-api>7.0.105</version.tomcat-servlet-api>
   </properties>
 
   <dependencies>
@@ -81,27 +80,6 @@
     </resources>
 
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>${version.maven-checkstyle-plugin}</version>
-        <executions>
-          <execution>
-            <id>validate</id>
-            <phase>validate</phase>
-            <configuration>
-              <configLocation>https://raw.githubusercontent.com/dbmdz/development/master/code-quality/checkstyle.xml</configLocation>
-              <encoding>UTF-8</encoding>
-              <consoleOutput>true</consoleOutput>
-              <failsOnError>true</failsOnError>
-              <linkXRef>false</linkXRef>
-            </configuration>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>de.digitalcollections.rosetta</groupId>
   <artifactId>rosetta-openwayback-vpp</artifactId>
-  <version>1.0.2-RELEASE</version>
+  <version>1.0.2-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>MDZ DLDC: Rosetta OpenWayback VPP</name>
@@ -15,7 +15,7 @@
     <!-- Dependencies -->
     <version.assertj>3.17.0</version.assertj>
     <version.dps-sdk>6.3.0</version.dps-sdk>
-    <version.junit-jupiter>5.7.0-RC1</version.junit-jupiter>
+    <version.junit-jupiter>5.6.2</version.junit-jupiter>
     <version.mockito-all>2.0.2-beta</version.mockito-all>
     <version.log4j>1.2.17</version.log4j>
     <!-- Plugins -->

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>de.digitalcollections.rosetta</groupId>
   <artifactId>rosetta-openwayback-vpp</artifactId>
-  <version>1.0.1-RELEASE</version>
+  <version>1.0.2-RELEASE</version>
   <packaging>jar</packaging>
 
   <name>MDZ DLDC: Rosetta OpenWayback VPP</name>

--- a/src/main/java/de/digitalcollections/rosetta/vpp/openwayback/OpenWaybackVpp.java
+++ b/src/main/java/de/digitalcollections/rosetta/vpp/openwayback/OpenWaybackVpp.java
@@ -30,7 +30,8 @@ public class OpenWaybackVpp extends AbstractViewerPreProcessor {
     execute(new DnxDocumentHelper(getDnx()), getViewContext());
   }
 
-  void execute(DnxDocumentHelper documentHelper, Map<String, String> viewContext) throws ParseException, UnsupportedEncodingException {
+  void execute(DnxDocumentHelper documentHelper, Map<String, String> viewContext)
+      throws ParseException, UnsupportedEncodingException {
     if (hasRequestedDetail(viewContext)) {
       additionalParameters = createUrlPath(documentHelper.getWebHarvesting(), viewContext);
     } else {
@@ -38,11 +39,15 @@ public class OpenWaybackVpp extends AbstractViewerPreProcessor {
     }
   }
 
-  String createUrlPath(DnxDocumentHelper.WebHarvesting webHarvesting, Map<String, String> viewContext) throws ParseException, UnsupportedEncodingException {
+  String createUrlPath(
+      DnxDocumentHelper.WebHarvesting webHarvesting, Map<String, String> viewContext)
+      throws ParseException, UnsupportedEncodingException {
     String marker = getMarker(viewContext);
     return marker
-      + waybackUrlService.createDetailUrlPath(webHarvesting.getPrimarySeedURL(), metadataService.parseHarvestDate(webHarvesting.getHarvestDate()))
-      + marker;
+        + waybackUrlService.createDetailUrlPath(
+            webHarvesting.getPrimarySeedURL(),
+            metadataService.parseHarvestDate(webHarvesting.getHarvestDate()))
+        + marker;
   }
 
   @Override
@@ -58,8 +63,8 @@ public class OpenWaybackVpp extends AbstractViewerPreProcessor {
     return viewContext.containsKey(DETAIL_KEY) && "true".equals(viewContext.get(DETAIL_KEY));
   }
 
-  String createOverviewQuery(DnxDocumentHelper.WebHarvesting webHarvesting) throws UnsupportedEncodingException {
+  String createOverviewQuery(DnxDocumentHelper.WebHarvesting webHarvesting)
+      throws UnsupportedEncodingException {
     return waybackUrlService.createOverviewQueryString(webHarvesting.getPrimarySeedURL());
   }
-
 }

--- a/src/main/java/de/digitalcollections/rosetta/vpp/openwayback/service/MetadataService.java
+++ b/src/main/java/de/digitalcollections/rosetta/vpp/openwayback/service/MetadataService.java
@@ -6,10 +6,10 @@ import java.util.Date;
 
 public class MetadataService {
 
-  private static final SimpleDateFormat HARVEST_DATE_FORMAT = new SimpleDateFormat("dd/MM/yyyy HH:mm:ss");
+  private static final SimpleDateFormat HARVEST_DATE_FORMAT =
+      new SimpleDateFormat("dd/MM/yyyy HH:mm:ss");
 
   public Date parseHarvestDate(String source) throws ParseException {
     return HARVEST_DATE_FORMAT.parse(source);
   }
-
 }

--- a/src/main/java/de/digitalcollections/rosetta/vpp/openwayback/service/WaybackUrlService.java
+++ b/src/main/java/de/digitalcollections/rosetta/vpp/openwayback/service/WaybackUrlService.java
@@ -15,8 +15,7 @@ public class WaybackUrlService {
     return WAYBACK_DATE_FORMAT.format(date);
   }
 
-  public String createDetailUrlPath(String seed, Date harvestDate)
-      throws UnsupportedEncodingException {
+  public String createDetailUrlPath(String seed, Date harvestDate) {
     return "/" + urlDateString(harvestDate) + "/" + seed;
   }
 

--- a/src/main/java/de/digitalcollections/rosetta/vpp/openwayback/service/WaybackUrlService.java
+++ b/src/main/java/de/digitalcollections/rosetta/vpp/openwayback/service/WaybackUrlService.java
@@ -5,19 +5,18 @@ import java.net.URLEncoder;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
-/**
- * Prepare data for OpenWayback.
- *
- */
+/** Prepare data for OpenWayback. */
 public class WaybackUrlService {
 
-  private static final SimpleDateFormat WAYBACK_DATE_FORMAT = new SimpleDateFormat("yyyyMMddHHmmss");
+  private static final SimpleDateFormat WAYBACK_DATE_FORMAT =
+      new SimpleDateFormat("yyyyMMddHHmmss");
 
   String urlDateString(Date date) {
     return WAYBACK_DATE_FORMAT.format(date);
   }
 
-  public String createDetailUrlPath(String seed, Date harvestDate) throws UnsupportedEncodingException {
+  public String createDetailUrlPath(String seed, Date harvestDate)
+      throws UnsupportedEncodingException {
     return "/" + urlDateString(harvestDate) + "/" + seed;
   }
 
@@ -28,5 +27,4 @@ public class WaybackUrlService {
   private String encode(String value) throws UnsupportedEncodingException {
     return URLEncoder.encode(value, "UTF-8");
   }
-
 }

--- a/src/main/java/de/digitalcollections/rosetta/vpp/openwayback/service/WaybackUrlService.java
+++ b/src/main/java/de/digitalcollections/rosetta/vpp/openwayback/service/WaybackUrlService.java
@@ -18,7 +18,7 @@ public class WaybackUrlService {
   }
 
   public String createDetailUrlPath(String seed, Date harvestDate) throws UnsupportedEncodingException {
-    return encode("/" + urlDateString(harvestDate) + "/" + seed);
+    return "/" + urlDateString(harvestDate) + "/" + seed;
   }
 
   public String createOverviewQueryString(String seed) throws UnsupportedEncodingException {

--- a/src/test/java/de/digitalcollections/rosetta/vpp/openwayback/OpenWaybackVppTest.java
+++ b/src/test/java/de/digitalcollections/rosetta/vpp/openwayback/OpenWaybackVppTest.java
@@ -1,5 +1,10 @@
 package de.digitalcollections.rosetta.vpp.openwayback;
 
+import static java.util.Collections.emptyMap;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
 import com.exlibris.digitool.common.dnx.DnxDocumentHelper;
 import com.exlibris.dps.sdk.access.AccessException;
 import java.io.UnsupportedEncodingException;
@@ -8,11 +13,6 @@ import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import static java.util.Collections.emptyMap;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class OpenWaybackVppTest {
 
@@ -29,16 +29,16 @@ public class OpenWaybackVppTest {
   }
 
   @Test
-  public void createUrlPathResultShouldStartAndEndWithMarkers() throws ParseException, UnsupportedEncodingException {
+  public void createUrlPathResultShouldStartAndEndWithMarkers()
+      throws ParseException, UnsupportedEncodingException {
     String marker = vpp.getMarker(emptyMap());
     String path = vpp.createUrlPath(webHarvesting, emptyMap());
-    assertThat(path)
-      .startsWith(marker)
-      .endsWith(marker);
+    assertThat(path).startsWith(marker).endsWith(marker);
   }
 
   @Test
-  public void createUrlPathResultShouldContainUrlPath() throws ParseException, UnsupportedEncodingException {
+  public void createUrlPathResultShouldContainUrlPath()
+      throws ParseException, UnsupportedEncodingException {
     String path = vpp.createUrlPath(webHarvesting, emptyMap());
     assertThat(path).contains("/20140312135704/http://wwww.bahn.de");
   }
@@ -69,7 +69,8 @@ public class OpenWaybackVppTest {
   }
 
   @Test
-  public void executeShouldRunDetailIfRequested() throws ParseException, UnsupportedEncodingException {
+  public void executeShouldRunDetailIfRequested()
+      throws ParseException, UnsupportedEncodingException {
     DnxDocumentHelper documentHelper = mock(DnxDocumentHelper.class);
     when(documentHelper.getWebHarvesting()).thenReturn(webHarvesting);
 
@@ -80,7 +81,8 @@ public class OpenWaybackVppTest {
   }
 
   @Test
-  public void executeShouldRunOverviewIfDetailIsNotRequested() throws ParseException, UnsupportedEncodingException {
+  public void executeShouldRunOverviewIfDetailIsNotRequested()
+      throws ParseException, UnsupportedEncodingException {
     DnxDocumentHelper documentHelper = mock(DnxDocumentHelper.class);
     when(documentHelper.getWebHarvesting()).thenReturn(webHarvesting);
     vpp.execute(documentHelper, emptyMap());
@@ -98,5 +100,4 @@ public class OpenWaybackVppTest {
   public void getMarkerShouldHaveDefaultValue() {
     assertThat(vpp.getMarker(emptyMap())).isEqualTo("@");
   }
-
 }

--- a/src/test/java/de/digitalcollections/rosetta/vpp/openwayback/OpenWaybackVppTest.java
+++ b/src/test/java/de/digitalcollections/rosetta/vpp/openwayback/OpenWaybackVppTest.java
@@ -40,7 +40,7 @@ public class OpenWaybackVppTest {
   @Test
   public void createUrlPathResultShouldContainUrlPath() throws ParseException, UnsupportedEncodingException {
     String path = vpp.createUrlPath(webHarvesting, emptyMap());
-    assertThat(path).contains("%2F20140312135704%2Fhttp%3A%2F%2Fwwww.bahn.de");
+    assertThat(path).contains("/20140312135704/http://wwww.bahn.de");
   }
 
   @Test

--- a/src/test/java/de/digitalcollections/rosetta/vpp/openwayback/service/MetadataServiceTest.java
+++ b/src/test/java/de/digitalcollections/rosetta/vpp/openwayback/service/MetadataServiceTest.java
@@ -1,5 +1,7 @@
 package de.digitalcollections.rosetta.vpp.openwayback.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
@@ -7,8 +9,6 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class MetadataServiceTest {
 
@@ -26,7 +26,7 @@ public class MetadataServiceTest {
     Calendar calendar = new GregorianCalendar();
     calendar.set(2012, 10, 1, 23, 11, 5);
     Date date = calendar.getTime();
-    assertThat(metadataService.parseHarvestDate(FORMAT.format(date)).toString()).isEqualTo(date.toString());
+    assertThat(metadataService.parseHarvestDate(FORMAT.format(date)).toString())
+        .isEqualTo(date.toString());
   }
-
 }

--- a/src/test/java/de/digitalcollections/rosetta/vpp/openwayback/service/WaybackUrlServiceTest.java
+++ b/src/test/java/de/digitalcollections/rosetta/vpp/openwayback/service/WaybackUrlServiceTest.java
@@ -29,7 +29,7 @@ public class WaybackUrlServiceTest {
   @Test
   public void createDetailUrlPathShouldReturnValidPath() throws ParseException, UnsupportedEncodingException {
     Date date = FORMAT.parse("01/08/2012 23:07:05");
-    assertThat(service.createDetailUrlPath("http://example.com", date)).isEqualTo("%2F20120801230705%2Fhttp%3A%2F%2Fexample.com");
+    assertThat(service.createDetailUrlPath("http://example.com", date)).isEqualTo("/20120801230705/http://example.com");
   }
 
   @Test

--- a/src/test/java/de/digitalcollections/rosetta/vpp/openwayback/service/WaybackUrlServiceTest.java
+++ b/src/test/java/de/digitalcollections/rosetta/vpp/openwayback/service/WaybackUrlServiceTest.java
@@ -1,13 +1,13 @@
 package de.digitalcollections.rosetta.vpp.openwayback.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.io.UnsupportedEncodingException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class WaybackUrlServiceTest {
 
@@ -27,14 +27,17 @@ public class WaybackUrlServiceTest {
   }
 
   @Test
-  public void createDetailUrlPathShouldReturnValidPath() throws ParseException, UnsupportedEncodingException {
+  public void createDetailUrlPathShouldReturnValidPath()
+      throws ParseException, UnsupportedEncodingException {
     Date date = FORMAT.parse("01/08/2012 23:07:05");
-    assertThat(service.createDetailUrlPath("http://example.com", date)).isEqualTo("/20120801230705/http://example.com");
+    assertThat(service.createDetailUrlPath("http://example.com", date))
+        .isEqualTo("/20120801230705/http://example.com");
   }
 
   @Test
-  public void createOverviewQueryStringShouldReturnValidQueryString() throws UnsupportedEncodingException {
-    assertThat(service.createOverviewQueryString("http://example.com")).isEqualTo("url=http%3A%2F%2Fexample.com");
+  public void createOverviewQueryStringShouldReturnValidQueryString()
+      throws UnsupportedEncodingException {
+    assertThat(service.createOverviewQueryString("http://example.com"))
+        .isEqualTo("url=http%3A%2F%2Fexample.com");
   }
-
 }


### PR DESCRIPTION
* Remove URL-encoding in detail mode:
URL-encoding the parameter `@/<timestamp>/<seed-url>@` in detail mode leads to 404-errors, because OpenWayback is unable to resolve the request.
* Migrate to Date Time API
* Add spotbugs
* Update dependencies

